### PR TITLE
Import with the .vue

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -7,7 +7,7 @@
 
 <script>
 import MyFooter from '~components/Footer.vue'
-import Breadcrumb from 'vue-bulma-breadcrumb'
+import Breadcrumb from 'vue-bulma-breadcrumb/src/Breadcrumb.vue'
 
 export default {
   components: {


### PR DESCRIPTION
We need to give the full path to webpack to apply the right loader (otherwise, babel-loader was called).